### PR TITLE
Update default data node.

### DIFF
--- a/__tests__/unit/database.spec.js
+++ b/__tests__/unit/database.spec.js
@@ -9,7 +9,7 @@ const Reference = require('../../lib/reference');
 const { defaultConfig, DEFAULT_APP_KEY } = require('../../lib/constants');
 
 let database;
-const app = new App(() => {}, defaultConfig, DEFAULT_APP_KEY);
+const app = new App(() => { }, defaultConfig, DEFAULT_APP_KEY);
 describe('Database testing suite', () => {
   beforeEach(() => {
     jest.addMatchers(immutableMatchers);
@@ -76,7 +76,7 @@ describe('Database testing suite', () => {
   });
 
   it('should initialize an empty database', () => {
-    expect(database._data).toBe(null);
+    expect(database._data).toEqualImmutable(Immutable.fromJS({}));
   });
 
   it('should transform array into maps', () => {
@@ -90,7 +90,7 @@ describe('Database testing suite', () => {
   });
 
   it('should return current data', () => {
-    expect(database._getData()).toEqual(null);
+    expect(database._getData()).toEqualImmutable(Immutable.fromJS({}));
   });
 
   // TESTING UTILITIES

--- a/lib/database.js
+++ b/lib/database.js
@@ -22,7 +22,7 @@ class Database {
     this.app = app;
 
     this._online = true;
-    this._data = Immutable.fromJS(null);
+    this._data = Immutable.fromJS({});
     this._callbacks = getInitialCallbackSettings();
 
     // this.goOffline = () => {};


### PR DESCRIPTION
**Issue:**
When attempting to set the value of a child without first defining mock data a TypeError is thrown.

**Sample code:**
```javascript
import { AdminRoot, constants as Constants  } from 'firebase-admin-mock'

admin = new AdminRoot()
admin.initializeApp({
    databaseUrl: Constants.DEFAULT_DATABASE_URL,
})
  
// Without the below line.
// admin.setMockData({ foo: 'bar' })

admin.database().ref('test_key').set('here_is_a_val', () => { }).then(() => {
    console.log('Success!')
}).catch((error) => {
    console.log('Error occurred:' + error.message)
})
```

**Expected behavior:**
`test_key` is set successfully with value `here_is_a_val` and the promise resolves with `Success!`

**Actual behavior:**
The following TypeError is thrown:`TypeError: Cannot read property 'setIn' of null`

**Proposed changes:**
The issue is due to the initial data being set to null. The default root was updated to be `{}` as opposed to `null`.