### PR TITLE
Wrap optional callbacks with conditionals to prevent errors.

### DIFF
--- a/__tests__/unit/data-snapshot.spec.js
+++ b/__tests__/unit/data-snapshot.spec.js
@@ -8,7 +8,5 @@ describe('DataSnapshot testing suite', () => {
     dataSnapshot = new DataSnapshot(data);
   });
 
-  it('should', () => {
-
-  });
+  it('placeholder')
 });

--- a/__tests__/unit/reference.spec.js
+++ b/__tests__/unit/reference.spec.js
@@ -124,7 +124,7 @@ describe('Reference testing suite', () => {
 
 
   // .remove()
-  it('should run without errors when calling remove without a callbacks', () => {
+  it('should run without errors when calling remove without a callback', () => {
     ref = new Reference(app);
 
     return expect(ref.remove()).resolves.toBe(undefined);
@@ -157,13 +157,15 @@ describe('Reference testing suite', () => {
     }
   });
 
-  it('should delete value when set is called with null', async () => {
+  it('should delete value when set is called with null', (done) => {
     ref = new Reference(app);
 
-    await ref.set(null);
-    const snapshot = await ref.once('value');
-
-    expect(snapshot.val()).toBe(null);
+    ref.set(null)
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toBe(null);
+        done();
+      });
   });
 
   it('should run without errors when calling set with a callback', (done) => {
@@ -180,25 +182,29 @@ describe('Reference testing suite', () => {
     });
   });
 
-  it('should run without errors when calling set without a callback', async () => {
+  it('should run without errors when calling set without a callback', (done) => {
     ref = new Reference(app);
 
-    await ref.set('foo_bar');
-    const snapshot = await ref.once('value');
-
-    expect(snapshot.val()).toBe('foo_bar');
+    ref.set('foo_bar')
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toBe('foo_bar');
+        done();
+      });
   });
 
-  it('should run without errors when calling set on a child key that does not exist', async () => {
+  it('should run without errors when calling set on a child key that does not exist', (done) => {
     ref = new Reference(app);
 
-    await ref.child('path/to/foo').set('bar');
-    const snapshot = await ref.child('path/to/foo').once('value');
-
-    expect(snapshot.val()).toBe('bar');
+    ref.child('path/to/foo').set('bar')
+      .then(() => ref.child('path/to/foo').once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toBe('bar');
+        done();
+      });
   });
 
-  it('should run without errors when calling set with complex data', async () => {
+  it('should run without errors when calling set with complex data', (done) => {
     ref = new Reference(app);
 
     const data = {
@@ -208,10 +214,12 @@ describe('Reference testing suite', () => {
       },
     };
 
-    await ref.set(data);
-    const snapshot = await ref.once('value');
-
-    expect(snapshot.val()).toEqual(data);
+    ref.set(data)
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toEqual(data);
+        done();
+      });
   });
 
   // .setPriority()
@@ -232,16 +240,18 @@ describe('Reference testing suite', () => {
     }
   });
 
-  it('should delete value when update is called with null', async () => {
+  it('should delete value when update is called with null', (done) => {
     ref = new Reference(app);
 
-    await ref.update(null);
-    const snapshot = await ref.once('value');
-
-    expect(snapshot.val()).toBe(null);
+    ref.update(null)
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toBe(null);
+        done();
+      });
   });
 
-  it('should update the value of the ref when update is called with a new non-object value', async (done) => {
+  it('should update the value of the ref when update is called with a new non-object value', (done) => {
     ref = new Reference(app);
 
     const dataSet = {
@@ -249,19 +259,25 @@ describe('Reference testing suite', () => {
       bar: 'foo',
     };
 
-    await ref.set(dataSet);
-    const snapshot = await ref.once('value');
-    expect(snapshot.val()).toEqual(dataSet);
+    ref.set(dataSet)
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toEqual(dataSet);
+      })
+      .then(() => {
+        const onComplete = () => {
+          ref.child('foo').once('value')
+            .then((fooSnapshot) => {
+              expect(fooSnapshot.val()).toBe('foo');
+              done();
+            });
+        };
 
-    ref.child('foo').update('foo', async () => {
-      const fooSnapshot = await ref.child('foo').once('value');
-
-      expect(fooSnapshot.val()).toBe('foo');
-      done();
-    });
+        ref.child('foo').update('foo', onComplete);
+      });
   });
 
-  it('should update the value of the ref when update is alled with an object value', async (done) => {
+  it('should update the value of the ref when update is called with an object value', (done) => {
     ref = new Reference(app);
 
     const dataSet = {
@@ -269,17 +285,21 @@ describe('Reference testing suite', () => {
       bar: 'foo',
     };
 
-    await ref.set(dataSet);
-    const snapshot = await ref.once('value');
-    expect(snapshot.val()).toEqual(dataSet);
+    ref.set(dataSet)
+      .then(() => ref.once('value'))
+      .then((snapshot) => {
+        expect(snapshot.val()).toEqual(dataSet);
+      })
+      .then(() => {
+        const onComplete = () => {
+          ref.child('foo').once('value')
+            .then((fooSnapshot) => {
+              expect(fooSnapshot.val()).toBe('foo');
+              done();
+            });
+        };
 
-    ref.update({
-      foo: 'foo',
-    }, async () => {
-      const fooSnapshot = await ref.child('foo').once('value');
-
-      expect(fooSnapshot.val()).toBe('foo');
-      done();
-    });
+        ref.update({ foo: 'foo' }, onComplete);
+      });
   });
 });

--- a/__tests__/unit/reference.spec.js
+++ b/__tests__/unit/reference.spec.js
@@ -5,16 +5,15 @@ const Reference = require('../../lib/reference');
 const Query = require('../../lib/query');
 const { DEFAULT_APP_KEY, defaultConfig } = require('../../lib/constants');
 
-const noop = () => { };
+const noop = () => {};
 
 let app;
 let ref;
 describe('Reference testing suite', () => {
-
   beforeEach(() => {
     app = new App(noop, defaultConfig, DEFAULT_APP_KEY);
     // TODO: Update databse so that this does not cause errors.
-    app.database().setMockData({ 'foo': 'bar' })
+    app.database().setMockData({ foo: 'bar' });
   });
 
   // constructor
@@ -131,7 +130,7 @@ describe('Reference testing suite', () => {
     return expect(ref.remove()).resolves.toBe(undefined);
   });
 
-  it('should run without errors when calling remove with key that does not exist', done => {
+  it('should run without errors when calling remove with key that does not exist', (done) => {
     ref = new Reference(app);
 
     ref.child('undefined_key').remove((res) => {
@@ -147,7 +146,7 @@ describe('Reference testing suite', () => {
   });
 
   // .set();
-  it('should throw an erorr when set is called without any arguments', done => {
+  it('should throw an erorr when set is called without any arguments', (done) => {
     ref = new Reference(app);
 
     try {
@@ -162,12 +161,12 @@ describe('Reference testing suite', () => {
     ref = new Reference(app);
 
     await ref.set(null);
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
 
     expect(snapshot.val()).toBe(null);
   });
 
-  it('should run without errors when calling set with a callback', done => {
+  it('should run without errors when calling set with a callback', (done) => {
     ref = new Reference(app);
 
     ref.set('foo_bar', (res) => {
@@ -185,16 +184,16 @@ describe('Reference testing suite', () => {
     ref = new Reference(app);
 
     await ref.set('foo_bar');
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
 
     expect(snapshot.val()).toBe('foo_bar');
-  })
+  });
 
   it('should run without errors when calling set on a child key that does not exist', async () => {
     ref = new Reference(app);
 
     await ref.child('path/to/foo').set('bar');
-    let snapshot = await ref.child('path/to/foo').once('value');
+    const snapshot = await ref.child('path/to/foo').once('value');
 
     expect(snapshot.val()).toBe('bar');
   });
@@ -203,17 +202,17 @@ describe('Reference testing suite', () => {
     ref = new Reference(app);
 
     const data = {
-      'foo_bar': 'foo_foo_bar_bar',
-      'bar': {
-        'bar_foo': 'bar_bar_bar'
-      }
-    }
+      foo_bar: 'foo_foo_bar_bar',
+      bar: {
+        bar_foo: 'bar_bar_bar',
+      },
+    };
 
     await ref.set(data);
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
 
     expect(snapshot.val()).toEqual(data);
-  })
+  });
 
   // .setPriority()
 
@@ -222,7 +221,7 @@ describe('Reference testing suite', () => {
   // .transaction()
 
   // .update()
-  it('should throw an error when update is called with no arguments', done => {
+  it('should throw an error when update is called with no arguments', (done) => {
     ref = new Reference(app);
 
     try {
@@ -237,52 +236,50 @@ describe('Reference testing suite', () => {
     ref = new Reference(app);
 
     await ref.update(null);
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
 
     expect(snapshot.val()).toBe(null);
   });
 
-  it('should update the value of the ref when update is called with a new non-object value', async done => {
-    ref = new Reference(app)
+  it('should update the value of the ref when update is called with a new non-object value', async (done) => {
+    ref = new Reference(app);
 
-    let dataSet = {
-      'foo': 'bar',
-      'bar': 'foo'
-    }
+    const dataSet = {
+      foo: 'bar',
+      bar: 'foo',
+    };
 
     await ref.set(dataSet);
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
     expect(snapshot.val()).toEqual(dataSet);
 
     ref.child('foo').update('foo', async () => {
-
-      let fooSnapshot = await ref.child('foo').once('value');
+      const fooSnapshot = await ref.child('foo').once('value');
 
       expect(fooSnapshot.val()).toBe('foo');
       done();
     });
   });
 
-  it('should update the value of the ref when update is alled with an object value', async done => {
-    ref = new Reference(app)
+  it('should update the value of the ref when update is alled with an object value', async (done) => {
+    ref = new Reference(app);
 
-    let dataSet = {
-      'foo': 'bar',
-      'bar': 'foo'
-    }
+    const dataSet = {
+      foo: 'bar',
+      bar: 'foo',
+    };
 
     await ref.set(dataSet);
-    let snapshot = await ref.once('value');
+    const snapshot = await ref.once('value');
     expect(snapshot.val()).toEqual(dataSet);
 
     ref.update({
-      'foo': 'foo'
+      foo: 'foo',
     }, async () => {
+      const fooSnapshot = await ref.child('foo').once('value');
 
-      let fooSnapshot = await ref.child('foo').once('value')
-
-      expect(fooSnapshot.val()).toBe('foo')
-      done()
+      expect(fooSnapshot.val()).toBe('foo');
+      done();
     });
-  })
+  });
 });

--- a/lib/database-accesors.js
+++ b/lib/database-accesors.js
@@ -323,7 +323,9 @@ class Reference extends Query {
         newData = null;
       }
       this._database._setData(newData);
-      onComplete();
+      if (onComplete) {
+        onComplete();
+      }
 
       return Promise.resolve();
     };
@@ -341,7 +343,9 @@ class Reference extends Query {
       const child = this._database._makeImmutable(value);
       const newData = data.setIn(this._pathArray, child);
       this._database._setData(newData);
-      onComplete();
+      if (onComplete) {
+        onComplete();
+      }
 
       return Promise.resolve();
     };
@@ -354,7 +358,7 @@ class Reference extends Query {
       throw new DeprecatedError('setWithPriority');
     };
 
-    this.transaction = (transactionUpdate, onComplete, applyLocally) => {};
+    this.transaction = (transactionUpdate, onComplete, applyLocally) => { };
 
     this.child = (childPath = '/') =>
       new Reference(app, concatenatePaths(path, childPath).join('/'));
@@ -382,7 +386,9 @@ class Reference extends Query {
       }, data);
 
       this._database._setData(nextTree);
-      onComplete();
+      if (onComplete) {
+        onComplete();
+      }
 
       // missing ThenableReference
     };

--- a/lib/database-accesors.js
+++ b/lib/database-accesors.js
@@ -297,7 +297,6 @@ class Reference extends Query {
     // this.onDisconnect = () => {};
 
     this.push = (value, onComplete) => {
-      const data = this._database._getData();
       const firebaseId = generateFirebaseToken();
       const child = this._database._makeImmutable(value);
 
@@ -305,8 +304,7 @@ class Reference extends Query {
         return; // missing ThenableReference
       }
 
-      const newData = data.setIn([...this._pathArray, firebaseId], child);
-      this._database._setData(newData);
+      this._database._setIn([...this._pathArray, firebaseId], value);
       if (onComplete) {
         onComplete();
       }
@@ -339,10 +337,7 @@ class Reference extends Query {
         return this.remove(onComplete);
       }
 
-      const data = this._database._getData();
-      const child = this._database._makeImmutable(value);
-      const newData = data.setIn(this._pathArray, child);
-      this._database._setData(newData);
+      this._database._setIn(this._pathArray, value);
       if (onComplete) {
         onComplete();
       }
@@ -382,7 +377,7 @@ class Reference extends Query {
 
       const nextTree = updateKeys.reduce((acc, key) => {
         const location = [...this._pathArray, ...getPaths(key)];
-        return setValue(location, values[key]);
+        return setValue(data, values[key], location);
       }, data);
 
       this._database._setData(nextTree);

--- a/lib/database.js
+++ b/lib/database.js
@@ -8,6 +8,7 @@ const Reference = require('./reference');
 const getValue = require('./get-value');
 const queryChildren = require('./query-children');
 const reconciliation = require('./reconciliation');
+const setValue = require('./set-value');
 const validateDataTree = require('./validate-data-tree');
 const { UPDATES, eventTypes } = require('./constants');
 
@@ -308,6 +309,13 @@ class Database {
       this._traverseUpdateTree(prev, next, updates);
 
       return data;
+    };
+
+    // sets a value deeply in the data tree
+    this._setIn = (pathArray, value) => {
+      const data = this._getData();
+      const newData = setValue(data, value, pathArray);
+      this._setData(newData);
     };
   }
 }


### PR DESCRIPTION
**Issue:**
When attempting to use remove/set/update functions within the `Reference` class without specifying the `onComplete` argument a TypeError is thrown. Example use cases for this include:
- No caring about what happens with the result of the function call
- Using a promise, for which specifying a callback is redundant.

**Sample code:**
```javascript
import { AdminRoot, constants as Constants  } from 'firebase-admin-mock'

admin = new AdminRoot()
admin.initializeApp({
    databaseUrl: Constants.DEFAULT_DATABASE_URL,
})

admin.setMockData({ foo: 'bar' })

admin.database().ref('test_key').set('here_is_a_val').then(() => {
    console.log('Success!')
}).catch((error) => {
    console.log('Error occurred:' + error.message)
})
```

**Expected behavior:**
`test_key` is set successfully with value `here_is_a_val` and the promise resolves with `Success!`

**Actual behavior:**
The following TypeError is thrown:`TypeError: onComplete is not a function`

**Proposed changes:**
Wrap the execution of the `onComplete` callbacks with a conditional to ensure that the callback is defined before it is executed.